### PR TITLE
Bug fix: Refactor `multi://` scheme to use correct URI template 

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -17,6 +17,7 @@ import (
 // WHOSONFIRST_DATA_TEMPLATE is a URL template for the root `data` directory in Who's On First data repositories.
 const WHOSONFIRST_DATA_TEMPLATE string = "https://raw.githubusercontent.com/whosonfirst-data/{repo}/master/data/"
 
+// findingaid is a struct defining a resolver.Resolver and *uritemplates.UriTemplate pair
 type findingaid struct {
 	// A resolver.Resolver instance used to derive the Who's On First repository name for an ID.
 	resolver resolver.Resolver
@@ -27,7 +28,6 @@ type findingaid struct {
 // type FindingAidReader implements the `whosonfirst/go-reader` interface for use with Who's On First finding aids.
 type FindingAidReader struct {
 	wof_reader.Reader
-	// ...
 	findingaids []*findingaid
 }
 
@@ -51,85 +51,49 @@ func NewFindingAidReader(ctx context.Context, uri string) (wof_reader.Reader, er
 	findingaids := make([]*findingaid, 0)
 
 	switch u.Host {
-	case "foo":
-	default:
+	case "multi":
 
-		uri_template := WHOSONFIRST_DATA_TEMPLATE
+		for _, rt_uri := range q["resolver"] {
 
-		if q.Get("template") != "" {
-			uri_template = q.Get("template")
-		}
+			rt_u, err := url.Parse(rt_uri)
 
-		uri_template, err = url.QueryUnescape(uri_template)
-
-		if err != nil {
-			return nil, fmt.Errorf("Failed to unescape ?template= parameter, %w", err)
-		}
-
-		t, err := uritemplates.Parse(uri_template)
-
-		if err != nil {
-			return nil, fmt.Errorf("Failed to parse URI template, %w", err)
-		}
-
-		q.Del("template")
-		u.RawQuery = q.Encode()
-
-		// findingaid://sqlite?dsn={DSN}
-		// findingaid://awsdynamo/{TABLENAME}
-		// findingaid://http(s)/{HOST}/{PATH}
-
-		// Set up resolver
-
-		var ru *url.URL
-
-		switch u.Host {
-		case "http", "https":
-
-			path := u.Path
-			path = strings.TrimLeft(path, "/")
-
-			parts := strings.Split(path, "/")
-
-			ru = &url.URL{}
-			ru.Scheme = u.Host
-			ru.Host = parts[0]
-
-			if len(parts) > 1 {
-				path = strings.Join(parts[1:], "/")
-				ru.Path = fmt.Sprintf("/%s", path)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to parse resolver URI, %w", err)
 			}
 
-			ru.RawQuery = u.RawQuery
+			fa_u := url.URL{}
+			fa_u.Scheme = "findingaid"
+			fa_u.Host = rt_u.Scheme
+			fa_u.Path = rt_u.Host + rt_u.Path
+			fa_u.RawQuery = rt_u.RawQuery
 
-		case "multi":
+			fa_uri := fa_u.String()
 
-			ru = &url.URL{}
-			ru.Scheme = u.Host
-			ru.RawQuery = u.RawQuery
+			r, t, err := deriveResolverAndTemplate(ctx, fa_uri)
 
-		default:
+			if err != nil {
+				return nil, fmt.Errorf("Failed to derive resolver and template from ?resolver= URI, %w", err)
+			}
 
-			path := u.Path
-			path = strings.TrimLeft(path, "/")
+			fa := &findingaid{
+				resolver: r,
+				template: t,
+			}
 
-			ru = &url.URL{}
-			ru.Scheme = u.Host
-			ru.Host = path
-			ru.RawQuery = u.RawQuery
+			findingaids = append(findingaids, fa)
 		}
 
-		r_uri := ru.String()
+	default:
 
-		f, err := resolver.NewResolver(ctx, r_uri)
+		r, t, err := deriveResolverAndTemplate(ctx, uri)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create resolver, %w", err)
+			return nil, err
 		}
 
 		findingaids = []*findingaid{
 			&findingaid{
-				resolver: f,
+				resolver: r,
 				template: t,
 			},
 		}
@@ -199,10 +163,10 @@ func (r *FindingAidReader) getReaderAndPath(ctx context.Context, uri string) (wo
 // to use for reading documents resolved by `uri`.
 func (r *FindingAidReader) getReaderURIAndPath(ctx context.Context, uri string) (string, string, error) {
 
+	// TBD: cache this?
+
 	logger := slog.Default()
 	logger = logger.With("uri", uri)
-
-	// TBD: cache this?
 
 	id, uri_args, err := wof_uri.ParseURI(uri)
 
@@ -244,9 +208,89 @@ func (r *FindingAidReader) getReaderURIAndPath(ctx context.Context, uri string) 
 			return "", "", fmt.Errorf("Failed to derive reader URI, %w", err)
 		}
 
-		logger.Debug("Return reader URI for resolver", "index", idx)
+		logger.Debug("Return reader URI for resolver", "reader_uri", reader_uri, "rel_path", rel_path)
 		return reader_uri, rel_path, nil
 	}
 
 	return "", "", fmt.Errorf("Failed to derive repo, no findingaid matches")
+}
+
+func deriveResolverAndTemplate(ctx context.Context, uri string) (resolver.Resolver, *uritemplates.UriTemplate, error) {
+
+	u, err := url.Parse(uri)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	q := u.Query()
+
+	uri_template := WHOSONFIRST_DATA_TEMPLATE
+
+	if q.Get("template") != "" {
+		uri_template = q.Get("template")
+	}
+
+	uri_template, err = url.QueryUnescape(uri_template)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to unescape ?template= parameter, %w", err)
+	}
+
+	t, err := uritemplates.Parse(uri_template)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to parse URI template, %w", err)
+	}
+
+	q.Del("template")
+	u.RawQuery = q.Encode()
+
+	// findingaid://sqlite?dsn={DSN}
+	// findingaid://awsdynamo/{TABLENAME}
+	// findingaid://http(s)/{HOST}/{PATH}
+
+	// Set up resolver
+
+	var ru *url.URL
+
+	switch u.Host {
+	case "http", "https":
+
+		path := u.Path
+		path = strings.TrimLeft(path, "/")
+
+		parts := strings.Split(path, "/")
+
+		ru = &url.URL{}
+		ru.Scheme = u.Host
+		ru.Host = parts[0]
+
+		if len(parts) > 1 {
+			path = strings.Join(parts[1:], "/")
+			ru.Path = fmt.Sprintf("/%s", path)
+		}
+
+		ru.RawQuery = u.RawQuery
+
+	default:
+
+		path := u.Path
+		path = strings.TrimLeft(path, "/")
+
+		ru = &url.URL{}
+		ru.Scheme = u.Host
+		ru.Host = path
+		ru.RawQuery = u.RawQuery
+	}
+
+	r_uri := ru.String()
+
+	r, err := resolver.NewResolver(ctx, r_uri)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create resolver, %w", err)
+	}
+
+	return r, t, nil
 }

--- a/reader.go
+++ b/reader.go
@@ -2,10 +2,9 @@ package findingaid
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io"
-	_ "log"
+	"log/slog"
 	"net/url"
 	"strings"
 
@@ -18,15 +17,18 @@ import (
 // WHOSONFIRST_DATA_TEMPLATE is a URL template for the root `data` directory in Who's On First data repositories.
 const WHOSONFIRST_DATA_TEMPLATE string = "https://raw.githubusercontent.com/whosonfirst-data/{repo}/master/data/"
 
+type findingaid struct {
+	// A resolver.Resolver instance used to derive the Who's On First repository name for an ID.
+	resolver resolver.Resolver
+	// A compiled `uritemplates.UriTemplate` to use resolving Who's On First finding aid URIs.
+	template *uritemplates.UriTemplate
+}
+
 // type FindingAidReader implements the `whosonfirst/go-reader` interface for use with Who's On First finding aids.
 type FindingAidReader struct {
 	wof_reader.Reader
-	// A SQLite `sql.DB` instance containing Who's On First finding aid data. (Optional)
-	db *sql.DB
-	// A compiled `uritemplates.UriTemplate` to use resolving Who's On First finding aid URIs.
-	template *uritemplates.UriTemplate
-	// A resolver.Resolver instance used to derive the Who's On First repository name for an ID.
-	resolver resolver.Resolver
+	// ...
+	findingaids []*findingaid
 }
 
 func init() {
@@ -46,82 +48,95 @@ func NewFindingAidReader(ctx context.Context, uri string) (wof_reader.Reader, er
 
 	q := u.Query()
 
-	uri_template := WHOSONFIRST_DATA_TEMPLATE
-
-	if q.Get("template") != "" {
-		uri_template = q.Get("template")
-	}
-
-	uri_template, err = url.QueryUnescape(uri_template)
-
-	if err != nil {
-		return nil, fmt.Errorf("Failed to unescape ?template= parameter, %w", err)
-	}
-
-	t, err := uritemplates.Parse(uri_template)
-
-	if err != nil {
-		return nil, fmt.Errorf("Failed to parse URI template, %w", err)
-	}
-
-	q.Del("template")
-	u.RawQuery = q.Encode()
-
-	// findingaid://sqlite?dsn={DSN}
-	// findingaid://awsdynamo/{TABLENAME}
-	// findingaid://http(s)/{HOST}/{PATH}
-
-	// Set up resolver
-
-	var ru *url.URL
+	findingaids := make([]*findingaid, 0)
 
 	switch u.Host {
-	case "http", "https":
-
-		path := u.Path
-		path = strings.TrimLeft(path, "/")
-
-		parts := strings.Split(path, "/")
-
-		ru = &url.URL{}
-		ru.Scheme = u.Host
-		ru.Host = parts[0]
-
-		if len(parts) > 1 {
-			path = strings.Join(parts[1:], "/")
-			ru.Path = fmt.Sprintf("/%s", path)
-		}
-
-		ru.RawQuery = u.RawQuery
-
-	case "multi":
-
-		ru = &url.URL{}
-		ru.Scheme = u.Host
-		ru.RawQuery = u.RawQuery
-
+	case "foo":
 	default:
 
-		path := u.Path
-		path = strings.TrimLeft(path, "/")
+		uri_template := WHOSONFIRST_DATA_TEMPLATE
 
-		ru = &url.URL{}
-		ru.Scheme = u.Host
-		ru.Host = path
-		ru.RawQuery = u.RawQuery
-	}
+		if q.Get("template") != "" {
+			uri_template = q.Get("template")
+		}
 
-	r_uri := ru.String()
+		uri_template, err = url.QueryUnescape(uri_template)
 
-	f, err := resolver.NewResolver(ctx, r_uri)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to unescape ?template= parameter, %w", err)
+		}
 
-	if err != nil {
-		return nil, fmt.Errorf("Failed to create resolver, %w", err)
+		t, err := uritemplates.Parse(uri_template)
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse URI template, %w", err)
+		}
+
+		q.Del("template")
+		u.RawQuery = q.Encode()
+
+		// findingaid://sqlite?dsn={DSN}
+		// findingaid://awsdynamo/{TABLENAME}
+		// findingaid://http(s)/{HOST}/{PATH}
+
+		// Set up resolver
+
+		var ru *url.URL
+
+		switch u.Host {
+		case "http", "https":
+
+			path := u.Path
+			path = strings.TrimLeft(path, "/")
+
+			parts := strings.Split(path, "/")
+
+			ru = &url.URL{}
+			ru.Scheme = u.Host
+			ru.Host = parts[0]
+
+			if len(parts) > 1 {
+				path = strings.Join(parts[1:], "/")
+				ru.Path = fmt.Sprintf("/%s", path)
+			}
+
+			ru.RawQuery = u.RawQuery
+
+		case "multi":
+
+			ru = &url.URL{}
+			ru.Scheme = u.Host
+			ru.RawQuery = u.RawQuery
+
+		default:
+
+			path := u.Path
+			path = strings.TrimLeft(path, "/")
+
+			ru = &url.URL{}
+			ru.Scheme = u.Host
+			ru.Host = path
+			ru.RawQuery = u.RawQuery
+		}
+
+		r_uri := ru.String()
+
+		f, err := resolver.NewResolver(ctx, r_uri)
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create resolver, %w", err)
+		}
+
+		findingaids = []*findingaid{
+			&findingaid{
+				resolver: f,
+				template: t,
+			},
+		}
 	}
 
 	r := &FindingAidReader{
-		resolver: f,
-		template: t,
+		findingaids: findingaids,
 	}
 
 	return r, nil
@@ -184,35 +199,54 @@ func (r *FindingAidReader) getReaderAndPath(ctx context.Context, uri string) (wo
 // to use for reading documents resolved by `uri`.
 func (r *FindingAidReader) getReaderURIAndPath(ctx context.Context, uri string) (string, string, error) {
 
+	logger := slog.Default()
+	logger = logger.With("uri", uri)
+
 	// TBD: cache this?
 
 	id, uri_args, err := wof_uri.ParseURI(uri)
 
 	if err != nil {
+		logger.Error("Failed to parse URI", "error", err)
 		return "", "", fmt.Errorf("Failed to parse URI, %w", err)
-	}
-
-	repo, err := r.resolver.GetRepo(ctx, id)
-
-	if err != nil {
-		return "", "", fmt.Errorf("Failed to derive repo, %w", err)
 	}
 
 	rel_path, err := wof_uri.Id2RelPath(id, uri_args)
 
 	if err != nil {
+		logger.Error("Failed to derive relative path for ID", "id", id, "error", err)
 		return "", "", fmt.Errorf("Failed to derive path, %w", err)
 	}
 
-	values := map[string]interface{}{
-		"repo": repo,
+	for idx, fa := range r.findingaids {
+
+		repo, err := fa.resolver.GetRepo(ctx, id)
+
+		if err != nil {
+
+			if err == resolver.ErrNotFound {
+				logger.Debug("Failed to derive repo with resolver", "index", idx, "error", err)
+				continue
+			}
+
+			logger.Error("Failed to derive repo with resolver", "index", idx, "error", err)
+			return "", "", fmt.Errorf("Failed to derive repo, %w", err)
+		}
+
+		values := map[string]interface{}{
+			"repo": repo,
+		}
+
+		reader_uri, err := fa.template.Expand(values)
+
+		if err != nil {
+			logger.Error("Failed to expand template for resolver", "index", idx, "template", fa.template, "error", err)
+			return "", "", fmt.Errorf("Failed to derive reader URI, %w", err)
+		}
+
+		logger.Debug("Return reader URI for resolver", "index", idx)
+		return reader_uri, rel_path, nil
 	}
 
-	reader_uri, err := r.template.Expand(values)
-
-	if err != nil {
-		return "", "", fmt.Errorf("Failed to derive reader URI, %w", err)
-	}
-
-	return reader_uri, rel_path, nil
+	return "", "", fmt.Errorf("Failed to derive repo, no findingaid matches")
 }

--- a/reader.go
+++ b/reader.go
@@ -50,6 +50,9 @@ func NewFindingAidReader(ctx context.Context, uri string) (wof_reader.Reader, er
 
 	findingaids := make([]*findingaid, 0)
 
+	logger := slog.Default()
+	logger = logger.With("scheme", u.Host)
+	
 	switch u.Host {
 	case "multi":
 
@@ -80,6 +83,7 @@ func NewFindingAidReader(ctx context.Context, uri string) (wof_reader.Reader, er
 				template: t,
 			}
 
+			logger.Debug("Add findingaid reader", "uri", fa_uri)
 			findingaids = append(findingaids, fa)
 		}
 
@@ -91,6 +95,8 @@ func NewFindingAidReader(ctx context.Context, uri string) (wof_reader.Reader, er
 			return nil, err
 		}
 
+		logger.Debug("Add findingaid reader", "uri", uri)
+		
 		findingaids = []*findingaid{
 			&findingaid{
 				resolver: r,
@@ -184,16 +190,17 @@ func (r *FindingAidReader) getReaderURIAndPath(ctx context.Context, uri string) 
 
 	for idx, fa := range r.findingaids {
 
+		logger.Debug("Get repo", "findingaid", idx, "id", id)
 		repo, err := fa.resolver.GetRepo(ctx, id)
 
 		if err != nil {
 
 			if err == resolver.ErrNotFound {
-				logger.Debug("Failed to derive repo with resolver", "index", idx, "error", err)
+				logger.Debug("Failed to derive repo with resolver, not found", "id", id)
 				continue
 			}
 
-			logger.Error("Failed to derive repo with resolver", "index", idx, "error", err)
+			logger.Error("Failed to derive repo with resolver", "id", id, "error", err)
 			return "", "", fmt.Errorf("Failed to derive repo, %w", err)
 		}
 
@@ -204,7 +211,7 @@ func (r *FindingAidReader) getReaderURIAndPath(ctx context.Context, uri string) 
 		reader_uri, err := fa.template.Expand(values)
 
 		if err != nil {
-			logger.Error("Failed to expand template for resolver", "index", idx, "template", fa.template, "error", err)
+			logger.Error("Failed to expand template for resolver", "repo", repo, "template", fa.template, "error", err)
 			return "", "", fmt.Errorf("Failed to derive reader URI, %w", err)
 		}
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -3,13 +3,13 @@ package findingaid
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/whosonfirst/go-reader/v2"
 )
-
-//
 
 func TestSQLiteFindingAid(t *testing.T) {
 
@@ -87,9 +87,22 @@ func TestHTTPFindingAid(t *testing.T) {
 
 func TestMultiFindingAid(t *testing.T) {
 
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	slog.Debug("Verbose logging enabled")
+
 	ctx := context.Background()
 
-	reader_uri := "findingaid://multi?resolver=https%3A%2F%2Fstatic.sfomuseum.org%2Ffindingaid%3Ftemplate%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fsfomuseum-data%2F%7Brepo%7D%2Fmain%2Fdata%2F&resolver=https%3A%2F%2Fdata.whosonfirst.org%2Ffindingaid%3Ftemplate%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fwhosonfirst-data%2F%7Brepo%7D%2Fmaster%2Fdata%2F"
+	reader_q := url.Values{}
+	reader_q.Add("resolver", "https://static.sfomuseum.org/findingaid?template=https://raw.githubusercontent.com/sfomuseum-data/{repo}/main/data/")
+	reader_q.Add("resolver", "https://data.whosonfirst.org/findingaid?template=https://raw.githubusercontent.com/whosonfirst-data/{repo}/master/data/")
+
+	reader_u := url.URL{}
+	reader_u.Scheme = "findingaid"
+	reader_u.Host = "multi"
+	reader_u.RawQuery = reader_q.Encode()
+
+	reader_uri := reader_u.String()
+	slog.Debug("Create reader", "uri", reader_uri)
 
 	r, err := reader.NewReader(ctx, reader_uri)
 
@@ -97,23 +110,29 @@ func TestMultiFindingAid(t *testing.T) {
 		t.Fatalf("Failed to create new reader, %v", err)
 	}
 
-	uri := "85865975"
-
-	fh, err := r.Read(ctx, uri)
-
-	if err != nil {
-		t.Fatalf("Failed to read %s, %v", uri, err)
+	tests := []string{
+		"85865975",
+		"1159396133",
 	}
 
-	fh.Close()
+	for _, uri := range tests {
 
-	exists, err := r.Exists(ctx, uri)
+		fh, err := r.Read(ctx, uri)
 
-	if err != nil {
-		t.Fatalf("Failed to determine if %s exists, %v", uri, err)
-	}
+		if err != nil {
+			t.Fatalf("Failed to read %s, %v", uri, err)
+		}
 
-	if !exists {
-		t.Fatalf("Expected %s to exists", uri)
+		fh.Close()
+
+		exists, err := r.Exists(ctx, uri)
+
+		if err != nil {
+			t.Fatalf("Failed to determine if %s exists, %v", uri, err)
+		}
+
+		if !exists {
+			t.Fatalf("Expected %s to exists", uri)
+		}
 	}
 }


### PR DESCRIPTION
* Refactor `multi://` scheme to use correct URI template; no public-facing changes
* Add internal `findingaid` struct to wrap resolver + URI template pairs
* Update internals to work with multiple `findingaid` structs; first match takes precedence
* Increased logging
* Update vendor deps